### PR TITLE
Admin Mode: Only teachers can register/unregister students

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/admin-mode-feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/admin-mode-feature.md
@@ -1,0 +1,8 @@
+Implement Admin Mode: restrict signup/unregister to teachers, add simple prompt-based login/logout UI
+
+- Only teachers (admins) can sign up or unregister students for activities
+- Added /admin/login and /admin/logout endpoints
+- Teacher credentials stored in src/teachers.json
+- Frontend: prompt-based login/logout, admin token stored in localStorage
+- UI disables signup/unregister for non-admins
+- No database or persistent sessions (in-memory only)

--- a/src/app.py
+++ b/src/app.py
@@ -5,14 +5,48 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request, Response, status, Cookie
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
+import json
+import secrets
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
+
+# Load teacher credentials
+TEACHERS_FILE = os.path.join(Path(__file__).parent, "teachers.json")
+with open(TEACHERS_FILE) as f:
+    TEACHERS = json.load(f)["teachers"]
+
+# Simple in-memory session store: {token: username}
+admin_sessions = {}
+def is_admin(token: str = None):
+    return token in admin_sessions
+
+# --- Admin login/logout endpoints ---
+@app.post("/admin/login")
+async def admin_login(request: Request, response: Response):
+    data = await request.json()
+    username = data.get("username")
+    password = data.get("password")
+    for teacher in TEACHERS:
+        if teacher["username"] == username and teacher["password"] == password:
+            token = secrets.token_hex(16)
+            admin_sessions[token] = username
+            response.set_cookie(key="admin_token", value=token, httponly=True)
+            return {"message": "Login successful", "token": token}
+    raise HTTPException(status_code=401, detail="Invalid credentials")
+
+@app.post("/admin/logout")
+def admin_logout(response: Response, admin_token: str = Cookie(None)):
+    if admin_token and admin_token in admin_sessions:
+        del admin_sessions[admin_token]
+        response.delete_cookie("admin_token")
+        return {"message": "Logged out"}
+    raise HTTPException(status_code=401, detail="Not logged in")
 
 # Mount the static files directory
 current_dir = Path(__file__).parent
@@ -88,45 +122,32 @@ def get_activities():
     return activities
 
 
+
+# Only admin (teacher) can sign up students
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
-    """Sign up a student for an activity"""
+def signup_for_activity(activity_name: str, email: str, admin_token: str = Cookie(None)):
+    if not is_admin(admin_token):
+        raise HTTPException(status_code=403, detail="Only teachers can sign up students.")
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
-
-    # Get the specific activity
     activity = activities[activity_name]
-
-    # Validate student is not already signed up
     if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
-        )
-
-    # Add student
+        raise HTTPException(status_code=400, detail="Student is already signed up")
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
 
 
+
+# Only admin (teacher) can unregister students
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
-    """Unregister a student from an activity"""
-    # Validate activity exists
+def unregister_from_activity(activity_name: str, email: str, admin_token: str = Cookie(None)):
+    if not is_admin(admin_token):
+        raise HTTPException(status_code=403, detail="Only teachers can unregister students.")
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
-
-    # Get the specific activity
     activity = activities[activity_name]
-
-    # Validate student is signed up
     if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
-        )
-
-    # Remove student
+        raise HTTPException(status_code=400, detail="Student is not signed up for this activity")
     activity["participants"].remove(email)
     return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -4,6 +4,67 @@ document.addEventListener("DOMContentLoaded", () => {
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
 
+  // Admin login/logout UI
+  const header = document.querySelector("header");
+  const adminBtn = document.createElement("button");
+  adminBtn.id = "admin-btn";
+  adminBtn.style.float = "right";
+  header.appendChild(adminBtn);
+
+  function isAdmin() {
+    return !!localStorage.getItem("admin_token");
+  }
+
+  function updateAdminBtn() {
+    if (isAdmin()) {
+      adminBtn.textContent = "Logout (Teacher)";
+    } else {
+      adminBtn.textContent = "Teacher Login";
+    }
+  }
+
+  async function adminLogin() {
+    const username = prompt("Teacher username:");
+    const password = prompt("Password:");
+    if (!username || !password) return;
+    const res = await fetch("/admin/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username, password })
+    });
+    if (res.ok) {
+      const data = await res.json();
+      localStorage.setItem("admin_token", data.token);
+      messageDiv.textContent = "Logged in as teacher.";
+      messageDiv.className = "success";
+      updateAdminBtn();
+    } else {
+      messageDiv.textContent = "Login failed.";
+      messageDiv.className = "error";
+    }
+    messageDiv.classList.remove("hidden");
+    setTimeout(() => messageDiv.classList.add("hidden"), 3000);
+  }
+
+  async function adminLogout() {
+    await fetch("/admin/logout", { method: "POST", credentials: "include" });
+    localStorage.removeItem("admin_token");
+    messageDiv.textContent = "Logged out.";
+    messageDiv.className = "info";
+    updateAdminBtn();
+    messageDiv.classList.remove("hidden");
+    setTimeout(() => messageDiv.classList.add("hidden"), 3000);
+  }
+
+  adminBtn.addEventListener("click", () => {
+    if (isAdmin()) {
+      adminLogout();
+    } else {
+      adminLogin();
+    }
+  });
+  updateAdminBtn();
+
   // Function to fetch activities from API
   async function fetchActivities() {
     try {
@@ -67,41 +128,37 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   }
 
-  // Handle unregister functionality
+  // Handle unregister functionality (admin only)
   async function handleUnregister(event) {
     const button = event.target;
     const activity = button.getAttribute("data-activity");
     const email = button.getAttribute("data-email");
-
+    if (!isAdmin()) {
+      messageDiv.textContent = "Only teachers can unregister students.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      setTimeout(() => messageDiv.classList.add("hidden"), 3000);
+      return;
+    }
     try {
       const response = await fetch(
-        `/activities/${encodeURIComponent(
-          activity
-        )}/unregister?email=${encodeURIComponent(email)}`,
+        `/activities/${encodeURIComponent(activity)}/unregister?email=${encodeURIComponent(email)}`,
         {
           method: "DELETE",
+          credentials: "include"
         }
       );
-
       const result = await response.json();
-
       if (response.ok) {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
-
-        // Refresh activities list to show updated participants
         fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";
       }
-
       messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
+      setTimeout(() => messageDiv.classList.add("hidden"), 5000);
     } catch (error) {
       messageDiv.textContent = "Failed to unregister. Please try again.";
       messageDiv.className = "error";
@@ -110,43 +167,38 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   }
 
-  // Handle form submission
+  // Handle form submission (admin only)
   signupForm.addEventListener("submit", async (event) => {
     event.preventDefault();
-
+    if (!isAdmin()) {
+      messageDiv.textContent = "Only teachers can sign up students.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      setTimeout(() => messageDiv.classList.add("hidden"), 3000);
+      return;
+    }
     const email = document.getElementById("email").value;
     const activity = document.getElementById("activity").value;
-
     try {
       const response = await fetch(
-        `/activities/${encodeURIComponent(
-          activity
-        )}/signup?email=${encodeURIComponent(email)}`,
+        `/activities/${encodeURIComponent(activity)}/signup?email=${encodeURIComponent(email)}`,
         {
           method: "POST",
+          credentials: "include"
         }
       );
-
       const result = await response.json();
-
       if (response.ok) {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
-
-        // Refresh activities list to show updated participants
         fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";
       }
-
       messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
+      setTimeout(() => messageDiv.classList.add("hidden"), 5000);
     } catch (error) {
       messageDiv.textContent = "Failed to sign up. Please try again.";
       messageDiv.className = "error";

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,6 @@
+{
+  "teachers": [
+    {"username": "teacher1", "password": "password1"},
+    {"username": "teacher2", "password": "password2"}
+  ]
+}


### PR DESCRIPTION
## Summary

This PR implements Admin Mode for the activities system:

- Only teachers (admins) can sign up or unregister students for activities
- Adds `/admin/login` and `/admin/logout` endpoints
- Teacher credentials are stored in `src/teachers.json`
- Frontend: prompt-based login/logout, admin token stored in localStorage
- UI disables signup/unregister for non-admins
- No database or persistent sessions (in-memory only)

### How to test
1. Click the "Teacher Login" button in the header and log in with a teacher account (see `src/teachers.json`).
2. Only after logging in as a teacher, you can sign up or unregister students.
3. Logout disables these actions for non-admins.

Closes #5 (Admin Mode)
